### PR TITLE
Switch to newer Jedis version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>redis.clients</groupId>
 			<artifactId>jedis</artifactId>
-			<version>2.7.2</version>
+			<version>2.9.0</version>
 		</dependency>
 		<dependency>
 			<groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
With Jedis 2.7.2 I get exceptions when creating a new JedisHost instance through the JConsole (via JMX). DefaultEvictionPolicy. It seems to be an issue related to class loaders: https://github.com/xetorthio/jedis/issues/1208
Switching to the new version fixed this problem since it uses commons-pool2 version 2.4 instead of 2.3.